### PR TITLE
Update pipeline with resource_types

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -63,3 +63,9 @@ resources:
   type: slack-notification
   source:
     url: {{slack-webhook-url}}
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource


### PR DESCRIPTION
For review, make non built-in resource types explicit, rather than relying on them being installed in Concourse. Has been fly'd.
@18F/cloud-gov-ops
